### PR TITLE
Groupnames

### DIFF
--- a/checkstyle.xml
+++ b/checkstyle.xml
@@ -108,7 +108,7 @@
     <module name="WhitespaceAround">
       <property name="allowEmptyConstructors" value="true"/>
       <property name="allowEmptyLambdas" value="true"/>
-      <property name="allowEmptyMethods" value="true"/>
+      <property name="allowEmptyMethods" value="false"/>
       <property name="allowEmptyTypes" value="true"/>
       <property name="allowEmptyLoops" value="true"/>
       <property name="ignoreEnhancedForColon" value="false"/>

--- a/pom.xml
+++ b/pom.xml
@@ -60,6 +60,7 @@
 				<configuration>
 					<violationSeverity>warning</violationSeverity>
 					<configLocation>checkstyle.xml</configLocation>
+					<includeTestSourceDirectory>true</includeTestSourceDirectory>
 				</configuration>
 				<dependencies>
 					<dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -45,6 +45,12 @@
 			<artifactId>mockito-core</artifactId>
 			<version>4.3.1</version>
 		</dependency>
+
+		<dependency>
+			<groupId>com.github.mpkorstanje</groupId>
+			<artifactId>simmetrics-core</artifactId>
+			<version>4.1.1</version>
+		</dependency>
 	</dependencies>
 
 	<build>

--- a/src/main/java/hh/slackbot/Slackbot/util/NameCompare.java
+++ b/src/main/java/hh/slackbot/Slackbot/util/NameCompare.java
@@ -12,7 +12,7 @@ import org.springframework.stereotype.Service;
 @Service
 public class NameCompare {
   private static final Logger logger = LoggerFactory.getLogger(NameCompare.class);
-  private static final float TRESHOLD = 0.8f;
+  private static final float THRESHOLD = 0.8f;
 
   public NameCompare() {}
 
@@ -27,7 +27,7 @@ public class NameCompare {
     List<String> hits = names.stream()
         .filter(n -> {
           float result = compareNames(n, name);
-          return result >= TRESHOLD;
+          return result >= THRESHOLD;
         })
         .collect(Collectors.toList());
 

--- a/src/main/java/hh/slackbot/Slackbot/util/NameCompare.java
+++ b/src/main/java/hh/slackbot/Slackbot/util/NameCompare.java
@@ -1,0 +1,40 @@
+package hh.slackbot.slackbot.util;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+import org.simmetrics.StringMetric;
+import org.simmetrics.metrics.StringMetrics;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Service;
+
+@Service
+public class NameCompare {
+  private static final Logger logger = LoggerFactory.getLogger(NameCompare.class);
+  private static final float TRESHOLD = 0.8f;
+
+  public NameCompare() {}
+
+  public float compareNames(String name1, String name2) {
+    StringMetric metric = StringMetrics.damerauLevenshtein();
+    float result = metric.compare(name1, name2);
+    logger.info("{}, {}, {}", name1, name2, result);
+    return result;
+  }
+
+  public List<String> compareToList(String name, List<String> names) {
+    List<String> hits = names.stream()
+        .filter(n -> {
+          float result = compareNames(n, name);
+          return result >= TRESHOLD;
+        })
+        .collect(Collectors.toList());
+
+    if (!hits.contains(name)) {
+      return hits;
+    }
+    return new ArrayList<>();
+  }
+  
+}

--- a/src/main/java/hh/slackbot/Slackbot/util/UsergroupUtil.java
+++ b/src/main/java/hh/slackbot/Slackbot/util/UsergroupUtil.java
@@ -110,8 +110,12 @@ public class UsergroupUtil {
     Usergroup group = null;
 
     try {
-      UsergroupsCreateResponse resp = client
-          .usergroupsCreate(UsergroupsCreateRequest.builder().token(TOKEN).name(name).build());
+      UsergroupsCreateResponse resp = client.usergroupsCreate(
+          UsergroupsCreateRequest.builder()
+            .token(TOKEN)
+            .name(name)
+            .handle(name)
+            .build());
 
       if (resp.isOk()) {
         group = resp.getUsergroup();

--- a/src/test/java/hh/slackbot/Slackbot/NameCompareTests.java
+++ b/src/test/java/hh/slackbot/Slackbot/NameCompareTests.java
@@ -1,0 +1,59 @@
+package hh.slackbot.slackbot;
+
+import hh.slackbot.slackbot.util.NameCompare;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+@SpringBootTest
+public class NameCompareTests {
+
+  @Autowired
+  private NameCompare comparer;
+
+  @Test
+  @DisplayName("Name comparer finds small typos, test 1")
+  public void comparerFindsTypos1() {
+    String name = "javascpirt";
+    String expectation = "javascript";
+    List<String> names = new ArrayList<String>(Arrays.asList(expectation, "typescript", "azure"));
+
+    List<String> result = comparer.compareToList(name, names);
+
+    Assertions.assertTrue(result.size() == 1, "returns 1 item");
+    Assertions.assertEquals(result.get(0), expectation, String.format("item is %s", expectation));
+  }
+
+  @Test
+  @DisplayName("Name comparer finds small typos, test 2")
+  public void comparerFindsTypos2() {
+    String name = "typoscrpit";
+    String expectation = "typescript";
+    List<String> names = new ArrayList<String>(Arrays.asList("javascript", expectation, "azure"));
+
+    List<String> result = comparer.compareToList(name, names);
+
+    Assertions.assertTrue(result.size() == 1, "returns 1 item");
+    Assertions.assertEquals(result.get(0), expectation, String.format("item is %s", expectation));
+  }
+
+  @Test
+  @DisplayName("Name comparer finds small typos, test 3")
+  public void comparerFindsTypos3() {
+    String name = "azere";
+    String expectation = "azure";
+    List<String> names = new ArrayList<String>(
+        Arrays.asList("javascript", "typescript", expectation));
+
+    List<String> result = comparer.compareToList(name, names);
+
+    Assertions.assertTrue(result.size() == 1, "returns 1 item");
+    Assertions.assertEquals(result.get(0), expectation, String.format("item is %s", expectation));
+  }
+  
+}

--- a/src/test/java/hh/slackbot/Slackbot/SlackAppTest.java
+++ b/src/test/java/hh/slackbot/Slackbot/SlackAppTest.java
@@ -3,8 +3,11 @@ package hh.slackbot.slackbot;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.mockito.Mockito.verify;
 
+import com.slack.api.app_backend.events.payload.EventsApiPayload;
+import com.slack.api.bolt.context.builtin.EventContext;
+import com.slack.api.methods.SlackApiException;
+import com.slack.api.model.event.AppMentionEvent;
 import java.io.IOException;
-
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -14,45 +17,37 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 
-import com.slack.api.app_backend.events.payload.EventsApiPayload;
-import com.slack.api.bolt.context.builtin.EventContext;
-import com.slack.api.methods.SlackApiException;
-import com.slack.api.model.event.AppMentionEvent;
-
 @SpringBootTest
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 class SlackAppTest {
 
   @Autowired
   SlackApp slackApp;
-	
+
   @MockBean
   private EventsApiPayload<AppMentionEvent> mockReq;
-  
+
   @MockBean
   private EventContext mockCtx;
-  
+
   @BeforeEach
   public void init() {
-	  MockitoAnnotations.openMocks(this);
+    MockitoAnnotations.openMocks(this);
   }
-  
 
   @Test
   @DisplayName("SlackApp is not null")
   void returnAppSuccessfully() {
-	  assertNotNull(slackApp.initSlackApp());  
+    assertNotNull(slackApp.initSlackApp());
   }
-  
-  
+
   @Test
   @DisplayName("SlackApp mention response is successful")
   void mentionResponseSuccessfully() throws IOException, SlackApiException {
+    // mockReq and mockCtx are defined with @MockBean
+    SlackApp.mentionResponse(mockReq, mockCtx);
 
-	  //mockReq and mockCtx are defined with @MockBean
-	  SlackApp.mentionResponse(mockReq, mockCtx);
-	 
-	  verify(mockCtx).say("Greetings :wave:");
-	  verify(mockCtx).ack();  
+    verify(mockCtx).say("Greetings :wave:");
+    verify(mockCtx).ack();
   }
 }

--- a/src/test/java/hh/slackbot/Slackbot/UsergroupHandlerTest.java
+++ b/src/test/java/hh/slackbot/Slackbot/UsergroupHandlerTest.java
@@ -79,6 +79,12 @@ class UsergroupHandlerTest {
           .users(users2)
           .name("disabled group")
           .dateDelete(1)
+          .build(),
+          Usergroup.builder()
+          .id("5555")
+          .users(users)
+          .name("sample2 group")
+          .dateDelete(0)
           .build()
     );
 
@@ -225,5 +231,28 @@ class UsergroupHandlerTest {
 
     verify(msgUtil).sendDirectMessage("Failed to add you to the group sample group", userId);
     verify(mockCtx).ack("Command failed to execute");
+  }
+
+  @Test
+  @DisplayName("Typo fails and sends message with similar results")
+  void typoFails() {
+    String userId = "user";
+    String userInput = "join sample gruop";
+
+    SlashCommandContext mockCtx = callWithMockValues(userId, userInput);
+
+    verify(msgUtil).sendDirectMessage("Did you mean: sample group", userId);
+    verify(mockCtx).ack("Command failed to execute");
+  }
+
+  @Test
+  @DisplayName("Similar group doesn't prevent joining an existing one")
+  void typoAllowsExisting() {
+    String userId = "user";
+    String userInput = "join sample group";
+
+    SlashCommandContext mockCtx = callWithMockValues(userId, userInput);
+
+    verify(mockCtx).ack();
   }
 }


### PR DESCRIPTION
Added utility function that checks similar existing group names and prevents the creation of them if they are too similar, ie. **typescript** and **tpyescript**.

Similarity threshold and used algorithm may still change as well as how the similarities are handled.