### PR TITLE
Group name's space-check + small fixes to UsergroupHandler

### DIFF
--- a/src/main/java/hh/nitor/slackbot/UsergroupHandler.java
+++ b/src/main/java/hh/nitor/slackbot/UsergroupHandler.java
@@ -86,9 +86,9 @@ public class UsergroupHandler {
     
     if (usergroupName.contains(" ")) {
       logger.info("The group name {} contains spaces or is empty. "
-        + "The operation has failed.", usergroupName);
+          + "The operation has failed.", usergroupName);
       messageUtil.sendEphemeralResponse("The group name can not contain spaces. "
-          + "Find more info by typing: /groups help" , userId, responseChannel);
+          + "Find more info by typing: /groups help", userId, responseChannel);
       return resp;
     }
     

--- a/src/main/java/hh/nitor/slackbot/UsergroupHandler.java
+++ b/src/main/java/hh/nitor/slackbot/UsergroupHandler.java
@@ -57,6 +57,7 @@ public class UsergroupHandler {
     logger.info("Processing the usergroup command's parameters...");
 
     if (payload.getText() == null) {
+      logger.info("There was no text input. Sending the Help message...");
       messageUtil.sendEphemeralResponse(
           blockMessager.helpText(false), "help", userId, responseChannel);
       return resp;
@@ -66,6 +67,7 @@ public class UsergroupHandler {
     command = params[0].toLowerCase();
     
     if (!(command.equalsIgnoreCase("join") || command.equalsIgnoreCase("leave"))) {
+      logger.info("The command {} does not exist. Sending the Help message...", command);
       messageUtil.sendEphemeralResponse(
           blockMessager.helpText(false), "help", userId, responseChannel);
       return resp;
@@ -73,19 +75,31 @@ public class UsergroupHandler {
 
     // "/groups"
     if (params.length < 2) {
+      logger.error("There was no group name in the input. "
+            + "Activating Help message...");
       messageUtil.sendEphemeralResponse(
           "Missing group name. Find more info by typing: /groups help", userId, responseChannel);
       return resp;
     }
-
+    
+    String usergroupName = params[1].toLowerCase();
+    
+    if (usergroupName.contains(" ")) {
+      logger.info("The group name {} contains spaces or is empty. "
+      + "The operation has failed.", usergroupName);
+      messageUtil.sendEphemeralResponse("The group name can not contain spaces. "
+               + "Find more info by typing: /groups help" , userId, responseChannel);
+      return resp;
+    }
+    
     // "/groups help"
     if (command.equalsIgnoreCase("help")) {
+      logger.info("The command was: help. Activating the Help message...");
       messageUtil.sendEphemeralResponse(
           blockMessager.helpText(false), "help", userId, responseChannel);
       return resp;
     }
 
-    String usergroupName = params[1].toLowerCase();
     // "/groups join/leave group_name"
     if (!finalizeUsergroupCommand(userId, command, usergroupName, responseChannel)) {
       messageUtil.sendEphemeralResponse(
@@ -93,8 +107,7 @@ public class UsergroupHandler {
 
       logger.error("The operation to {} the group {} has failed", command, usergroupName);
 
-      return ctx.ack("The operation has failed: please check "
-          + "that you have written the command correctly :x:");
+      return resp;
     }
     
     logger.info("The operation to {} the group {} has been successful", command, usergroupName);
@@ -162,18 +175,9 @@ public class UsergroupHandler {
 
     } else if (command.equalsIgnoreCase("leave")) {
       return removeUserFromGroup(userId, usergroup, responseChannel);
-
-    } else {
-      logger.error("The command {} does not exist", command);
-      messageUtil.sendEphemeralResponse(
-          String.format("The command %s is incorrect or does not exist. "
-           + "Please write \"/groups help\" to see the accurate commands", command),
-          userId,
-          responseChannel
-      );
-
-      return false;
     }
+    
+    return false;
   }
 
   /**

--- a/src/main/java/hh/nitor/slackbot/UsergroupHandler.java
+++ b/src/main/java/hh/nitor/slackbot/UsergroupHandler.java
@@ -76,7 +76,7 @@ public class UsergroupHandler {
     // "/groups"
     if (params.length < 2) {
       logger.error("There was no group name in the input. "
-            + "Activating Help message...");
+            + "Sending the Help message...");
       messageUtil.sendEphemeralResponse(
           "Missing group name. Find more info by typing: /groups help", userId, responseChannel);
       return resp;
@@ -94,7 +94,7 @@ public class UsergroupHandler {
     
     // "/groups help"
     if (command.equalsIgnoreCase("help")) {
-      logger.info("The command was: help. Activating the Help message...");
+      logger.info("The command was: help. Sending the Help message...");
       messageUtil.sendEphemeralResponse(
           blockMessager.helpText(false), "help", userId, responseChannel);
       return resp;
@@ -206,7 +206,7 @@ public class UsergroupHandler {
       messageUtil.sendEphemeralResponse(
           String.format("You are already in the group %s. "
           + "You can only join groups "
-          + " you are not a part of :warning:", group.getName()),
+          + "you are not a part of :warning:", group.getName()),
           userId,
           responseChannel
       );

--- a/src/main/java/hh/nitor/slackbot/UsergroupHandler.java
+++ b/src/main/java/hh/nitor/slackbot/UsergroupHandler.java
@@ -86,9 +86,9 @@ public class UsergroupHandler {
     
     if (usergroupName.contains(" ")) {
       logger.info("The group name {} contains spaces or is empty. "
-      + "The operation has failed.", usergroupName);
+        + "The operation has failed.", usergroupName);
       messageUtil.sendEphemeralResponse("The group name can not contain spaces. "
-               + "Find more info by typing: /groups help" , userId, responseChannel);
+          + "Find more info by typing: /groups help" , userId, responseChannel);
       return resp;
     }
     

--- a/src/test/java/hh/nitor/slackbot/UsergroupHandlerTest.java
+++ b/src/test/java/hh/nitor/slackbot/UsergroupHandlerTest.java
@@ -218,6 +218,20 @@ class UsergroupHandlerTest {
     verify(msgUtil).sendEphemeralResponse(anyList(), anyString(), eq(userId), eq("channel_id"));
     verify(mockCtx).ack();
   }
+  
+  @Test
+  @DisplayName("The command fails due to the spaces in the group's name")
+  void groupNameHasSpacesFails() {
+    String userId = "user";
+    String userInput = "join sample group";
+
+    SlashCommandContext mockCtx = callWithMockValues(userId, userInput);
+
+    verify(msgUtil).sendEphemeralResponse(
+            anyString(), eq(userId), eq("channel_id"));
+
+    verify(mockCtx).ack();
+  }
 
   @Test
   @DisplayName("Enabling group fails")
@@ -269,20 +283,6 @@ class UsergroupHandlerTest {
     String userInput = "join sample_group";
 
     SlashCommandContext mockCtx = callWithMockValues(userId, userInput);
-
-    verify(mockCtx).ack();
-  }
-  
-  @Test
-  @DisplayName("The command fails due to the spaces in the group's name")
-  void groupNameHasSpacesFails() {
-    String userId = "user";
-    String userInput = "join sample group";
-
-    SlashCommandContext mockCtx = callWithMockValues(userId, userInput);
-
-    verify(msgUtil).sendEphemeralResponse(
-            anyString(), eq(userId), eq("channel_id"));
 
     verify(mockCtx).ack();
   }

--- a/src/test/java/hh/nitor/slackbot/UsergroupHandlerTest.java
+++ b/src/test/java/hh/nitor/slackbot/UsergroupHandlerTest.java
@@ -253,7 +253,7 @@ class UsergroupHandlerTest {
   @DisplayName("Typo sends a blockit message")
   void typoFails() {
     String userId = "user";
-    String userInput = "join sample gruop";
+    String userInput = "join sample_gruop";
 
     SlashCommandContext mockCtx = callWithMockValues(userId, userInput);
 
@@ -269,6 +269,20 @@ class UsergroupHandlerTest {
     String userInput = "join sample_group";
 
     SlashCommandContext mockCtx = callWithMockValues(userId, userInput);
+
+    verify(mockCtx).ack();
+  }
+  
+  @Test
+  @DisplayName("The command fails due to the spaces in the group's name")
+  void groupNameHasSpacesFails() {
+    String userId = "user";
+    String userInput = "join sample group";
+
+    SlashCommandContext mockCtx = callWithMockValues(userId, userInput);
+
+    verify(msgUtil).sendEphemeralResponse(
+            anyString(), eq(userId), eq("channel_id"));
 
     verify(mockCtx).ack();
   }


### PR DESCRIPTION
First of all, sorry for multiple small changes inside one branch --> won't happen in the future.

I made some small changes:

-  I added some code that checks if the group's name contains spaces (example: nice group) 
       - if there are spaces in the group's name, the command is cancelled

- I removed one repetitive part from the finalizeUsergroupCommand:
      - It was an "else" part that checked if the command is **NOT** join or leave
      --> Not necessary anymore, because the check is now done in the beginning of the command (handleUsergroupCommand)

- I removed a string inside ctx.ack() from the handleUsergroupCommand:
      - Now that there are accurate error (and help) messages sent to user after each possible error, there is no more need for 
        the message inside ctx.ack()

- I added some new logger messages inside the checks/errors regarding the user input's correct syntax
      
- I fixed one test case (and added a new one): now the group name's spaces are taken into account during the tests
